### PR TITLE
202 fix UI and logic issues in event home and join organization page

### DIFF
--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -79,7 +79,7 @@ const Home = () => {
           color: "grey.600",
         }}
       >
-        Events
+        Upcoming Events
       </Typography>
       {requiredEvents.map((event) => (
         <Link

--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -79,7 +79,7 @@ const Home = () => {
           color: "grey.600",
         }}
       >
-        Your upcoming events
+        Events
       </Typography>
       {requiredEvents.map((event) => (
         <Link
@@ -94,7 +94,12 @@ const Home = () => {
       <Link
         variant="h6"
         component="h2"
-        sx={{ color: "#CF3D3C", textAlign: "center", underline: "hover" }}
+        sx={{
+          color: "#CF3D3C",
+          textAlign: "center",
+          underline: "hover",
+          mb: 2,
+        }}
         onClick={() => push(PATH_EVENTS.root)}
       >
         Load more events

--- a/src/sections/event-card/EventCard.js
+++ b/src/sections/event-card/EventCard.js
@@ -129,9 +129,15 @@ const EventCard = ({ user, event }) => {
                       />
                     </Box>
                     <DialogContentText
-                      display="flex"
+                      display="wrap"
                       justifyContent="center"
-                      sx={{ wordWrap: "inherit", pt: 2 }}
+                      sx={{
+                        wordWrap: "break-word",
+                        pt: 3,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
                     >
                       {event?.eventEthAddress}
                     </DialogContentText>

--- a/src/sections/events/Events.js
+++ b/src/sections/events/Events.js
@@ -46,7 +46,7 @@ const Events = () => {
       </Typography>
 
       {filteredUpcomingEvents.length !== 0
-        ? filteredUpcomingEvents.slice(0, 2).map((event) => (
+        ? filteredUpcomingEvents.slice(0, 4).map((event) => (
             <Link
               href={`/event/${event.id}`}
               style={{ textDecoration: "none" }}

--- a/src/sections/events/UpcomingEvents.js
+++ b/src/sections/events/UpcomingEvents.js
@@ -3,7 +3,7 @@ import { IconButton, Typography } from "@mui/material";
 import { Container, Box } from "@mui/system";
 import { EventCard } from "@sections/event-card";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
-import React from "react";
+import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { useRouter } from "next/router";
 
@@ -11,10 +11,21 @@ const UpcomingEvents = () => {
   const router = useRouter();
   const events = useSelector((state) => state.events);
   const currentDate = new Date();
+  const [showMore, setShowMore] = useState(false);
+  const [eventsToShow, setEventsToShow] = useState(5);
   const filteredUpcomingEvents =
     events.length !== 0 && events.success !== false
       ? events.filter((event) => new Date(event.endTimeStamp) >= currentDate)
       : [];
+
+  const handleLoadMore = () => {
+    if (eventsToShow < filteredUpcomingEvents.length) {
+      setEventsToShow(eventsToShow + 5);
+      if (!showMore) {
+        setShowMore(true);
+      }
+    }
+  };
   return (
     <Container>
       <IconButton color="primary" onClick={() => router.back()}>
@@ -30,19 +41,25 @@ const UpcomingEvents = () => {
         UPCOMING EVENTS
       </Typography>
       {filteredUpcomingEvents.length >= 1 ? (
-        filteredUpcomingEvents.map((event) => (
-          <EventCard key={event.id} event={event} />
-        ))
+        filteredUpcomingEvents
+          .slice(0, eventsToShow)
+          .map((event) => <EventCard key={event.id} event={event} />)
       ) : (
         <Typography variant="h6" textAlign="center">
           No upcoming Events.
         </Typography>
       )}
-      <Box>
-        <BorderlessButton sx={{ mt: 2, mb: 2, color: "secondary.main" }}>
-          Load More Events
-        </BorderlessButton>
-      </Box>
+      {filteredUpcomingEvents.length > 5 &&
+        eventsToShow < filteredUpcomingEvents.length && (
+          <Box>
+            <BorderlessButton
+              sx={{ mt: 2, mb: 2, color: "secondary.main" }}
+              onClick={handleLoadMore}
+            >
+              Load More Events
+            </BorderlessButton>
+          </Box>
+        )}
     </Container>
   );
 };

--- a/src/sections/organizations/JoinOrg.js
+++ b/src/sections/organizations/JoinOrg.js
@@ -3,6 +3,7 @@ import {
   Box,
   Card,
   Container,
+  Divider,
   Grid,
   IconButton,
   Modal,
@@ -82,7 +83,15 @@ export default function JoinOrg() {
       <IconButton color="primary" onClick={arrowBack}>
         <ArrowBackIosIcon />
       </IconButton>
-
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        <Typography variant="h4">Join Organization</Typography>
+      </Box>
+      <Divider />
       <Autocomplete
         disablePortal
         options={notJoinedOrg.map((list) => list.name)}


### PR DESCRIPTION
This issue features:
addition of join organization heading in joinOrg component
fixed ethAddress in dialog wrapped in home component and heading changed to events from your upcoming events
addition of load more logic in load more button in upcomingEvents page
display of 4 events in events page before load more button 
